### PR TITLE
[dart_lsc] Prepare for 1.0.0 version of sensors and package_info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.3
+
+* Prepare for 1.0.0 version of sensors and package_info. ([dart_lsc](http://github.com/amirh/dart_lsc))
+
 ## [0.4.0] - 2019-10-19
 
 * 修复BUG，使用方式发生变化

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_github_releases_service
 description: Use github releases to update the app.
-version: 0.4.2
+version: 0.4.3
 homepage: https://github.com/januwA/flutter_github_releases_service
 
 environment:
@@ -15,7 +15,7 @@ dependencies:
   path: ^1.6.4
   install_plugin: ^2.0.1
   permission_handler: ^4.2.0+hotfix.1
-  package_info: ^0.4.0+13
+  package_info: '>=0.4.0+13 <2.0.0'
   path_provider: ^1.5.1
 
   flutter_downloader: ^1.4.0


### PR DESCRIPTION
This should be a safe change, for more details see: https://github.com/flutter/flutter/wiki/Package-migration-to-1.0.0

This change was auto generated by [dart_lsc](https://github.com/amirh/dart_lsc).